### PR TITLE
 Add missing reference to util package

### DIFF
--- a/drop/journal_watcher_cgo.go
+++ b/drop/journal_watcher_cgo.go
@@ -8,6 +8,8 @@ import (
 	"github.com/golang/glog"
 	"strings"
 	"time"
+	
+	"github.com/box/kube-iptables-tailer/util"
 )
 
 // Watcher handles detecting any changes on the given journal and passing those changes through Go Channel to be parsed.
@@ -43,7 +45,7 @@ func (watcher *JournalWatcher) Run(logChangeCh chan<- string) {
 
 			return strings.Join([]string{
 				time.Unix(0, int64(entry.RealtimeTimestamp)*int64(time.Microsecond)).
-					Format(DefaultPacketDropLogTimeLayout),
+					Format(util.DefaultPacketDropLogTimeLayout),
 				hostname,
 				msg,
 			}, " ") + "\n", nil


### PR DESCRIPTION
https://github.com/box/kube-iptables-tailer/issues/10 causes `journal_watcher_cgo.go` to fail to compile due to a missing reference. This adds the required import of `github.com/box/kube-iptables-tailer/util` and fixes the reference to `DefaultPacketDropLogTimeLayout`.